### PR TITLE
Fix CI job fail if repo does not contain any .js files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,20 +7,35 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4.0.2
+    - name: Check for JS files
+      id: check_js
+      run: |
+        if find . -name "*.js" | grep .; then
+          echo "has_js=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_js=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Setup Node.js
+      if: steps.check_js.outputs.has_js == 'true'
+      uses: actions/setup-node@v4.0.2
       with:
         node-version: 22
 
     - name: Install npm
+      if: steps.check_js.outputs.has_js == 'true'
       run: npm i -g npm@10.8.1
       shell: bash
 
     - uses: actions/checkout@v4
 
     - name: Install Dependencies
+      if: steps.check_js.outputs.has_js == 'true'
       run: npm ci
       shell: bash
 
     - name: Run tests
+      if: steps.check_js.outputs.has_js == 'true'
       run: npm test
       shell: bash


### PR DESCRIPTION
This PR fix CI job fails if the repo that use this action.